### PR TITLE
Revert Appveyor runner to Visual Studio 2019

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@
 
 version: '{build}'
 max_jobs: 1
-image: WMF 5
+image: Visual Studio 2019
 # History plugin requires complete log
 #clone_depth: 5
 branches:


### PR DESCRIPTION
Windows Server 2012 is end of life. Switching to a new runner OS.